### PR TITLE
Serve built client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+server.log
+

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -10,7 +10,9 @@ const io = new Server(httpServer, {
   },
 });
 
+// Serve the compiled client bundle alongside static assets
 app.use(express.static('public'));
+app.use('/dist', express.static('dist/client'));
 
 interface InputState {
   up: boolean;


### PR DESCRIPTION
## Summary
- serve dist folder from express
- add gitignore to ignore dist and node_modules

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b8cc3ad1483268c963f8bf031f60e